### PR TITLE
Fix max steering angle

### DIFF
--- a/ranger_base/include/ranger_base/ranger_params.hpp
+++ b/ranger_base/include/ranger_base/ranger_params.hpp
@@ -30,13 +30,13 @@ struct RangerMiniV1Params {
   static constexpr double track =
       0.36;  // in meter (left & right wheel distance) //ranger-mini 0.364
   static constexpr double wheelbase =
-      0.36;  // in meter (front & rear wheel distance) //ranger-mini 0.494
+      0.36;  // in meter (front & rear wheel distance) //ranger-mini 0.364
 
   static constexpr double max_linear_speed = 1.5;   // in m/s
   static constexpr double max_angular_speed = 0.3;  // in rad/s
   static constexpr double max_speed_cmd = 5;        // in rad/s
 
-  static constexpr double max_steer_angle_central = 0.6981;  //~= 30.58 degree
+  static constexpr double max_steer_angle_central = 0.4280;  //~= 24.52 degree
   static constexpr double max_steer_angle_parallel = 0.6981;    // 40 degree
   static constexpr double max_round_angle = 0.935671;
   static constexpr double min_turn_radius = 0.536;
@@ -52,10 +52,10 @@ struct RangerMiniV2Params {
   static constexpr double max_angular_speed = 0.7853;  // in rad/s
   static constexpr double max_speed_cmd = 10.0;        // in rad/s
 
-  static constexpr double max_steer_angle_central = 0.6981;  //~= 30.58 degree
-  static constexpr double max_steer_angle_parallel = 1.570;     // 40 degree
+  static constexpr double max_steer_angle_central = 0.4782;  //~= 27.40 degree
+  static constexpr double max_steer_angle_parallel = 1.570;     // 180 degree
   static constexpr double max_round_angle = 0.935671;
-  static constexpr double min_turn_radius = 0.536;
+  static constexpr double min_turn_radius = 0.4764;
 };
 }  // namespace westonrobot
 


### PR DESCRIPTION
issue: 
ranger mini 2 should start spinning on the spot at max inner angle of 0.698 rads, however, spinning mode triggers earlier than expected.
fixed: 
* wrongly used central to inner angle conversion
* incorrect conversion formula
* rangermini2 params